### PR TITLE
ci: add release pipeline for GitHub Releases and NuGet

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,66 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Get version from tag
+        id: version
+        run: echo "value=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Restore
+        run: dotnet restore tests/ParquetBulkImporterTests/ParquetBulkImporterTests.csproj
+
+      - name: Build
+        run: dotnet build src/ParquetBulkImporter/ParquetBulkImporter.csproj -c Release --no-restore
+
+      - name: Test
+        run: dotnet test tests/ParquetBulkImporterTests/ParquetBulkImporterTests.csproj -c Release --no-build
+
+      - name: Pack NuGet
+        run: |
+          dotnet pack src/ParquetBulkImporter/ParquetBulkImporter.csproj \
+            -c Release \
+            --no-build \
+            -o ./artifacts \
+            /p:Version=${{ steps.version.outputs.value }} \
+            /p:PackageVersion=${{ steps.version.outputs.value }}
+
+      - name: Upload package artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: nuget-packages-${{ github.ref_name }}
+          path: artifacts/*
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            artifacts/*.nupkg
+            artifacts/*.snupkg
+          generate_release_notes: true
+
+      - name: Publish to NuGet.org
+        if: ${{ secrets.NUGET_API_KEY != '' }}
+        run: |
+          dotnet nuget push "artifacts/*.nupkg" \
+            --source https://api.nuget.org/v3/index.json \
+            --api-key "${{ secrets.NUGET_API_KEY }}" \
+            --skip-duplicate

--- a/README.md
+++ b/README.md
@@ -76,6 +76,13 @@ python -m unittest discover -s tests/parquet_bulk_import_test -p "test_*.py"
 docker compose up -d
 ```
 
+
+## Releases
+
+- Create a version tag like `v0.1.0` and push it to trigger the `Release` workflow.
+- The workflow builds, tests, creates `.nupkg/.snupkg`, and publishes a GitHub Release.
+- To also publish to NuGet.org, add repository secret `NUGET_API_KEY`.
+
 ## Repository Layout
 
 - `src/ParquetBulkImporter`: library source

--- a/src/ParquetBulkImporter/ParquetBulkImporter.csproj
+++ b/src/ParquetBulkImporter/ParquetBulkImporter.csproj
@@ -1,19 +1,34 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+
     <PublishSingleFile>false</PublishSingleFile>
     <PublishTrimmed>false</PublishTrimmed>
     <SelfContained>false</SelfContained>
     <Platforms>x64</Platforms>
-</PropertyGroup>
+
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <PackageId>ParquetBulkImporter</PackageId>
+    <Authors>celoibarros</Authors>
+    <Company>celoibarros</Company>
+    <Description>.NET 8 library for high-throughput Parquet to SQL Server bulk imports on Linux and Windows.</Description>
+    <PackageTags>parquet;sql-server;bulk-import;etl;dotnet;csharp</PackageTags>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/celoibarros/parquet-bulk-import-sqlserver</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/celoibarros/parquet-bulk-import-sqlserver</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.1" />
     <PackageReference Include="Parquet.Net" Version="5.2.0" />
-    
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary\n- add NuGet package metadata to the library csproj\n- add tag-triggered release workflow ()\n- pack and attach  to GitHub Release\n- optionally publish to NuGet.org when  secret is configured\n- document release process in README\n\n## How to use\n1. Merge this PR\n2. Add repository secret  (optional)\n3. Create and push a tag like \n4. Workflow creates a GitHub Release and publishes packages